### PR TITLE
Runtime misc: throw, fixes for objectExpr, namedPatt

### DIFF
--- a/spotter.ml
+++ b/spotter.ml
@@ -1,9 +1,5 @@
 open CamomileLibraryDefault.Camomile
 
-let logged label ch =
-  Printf.printf "%s%c..." label ch ;
-  ch
-
 type monte =
   < call: string -> monte list -> (monte * monte) list -> monte option
   ; stringOf: string
@@ -663,6 +659,10 @@ module MASTContext (Monte : MAST) = struct
     Printf.printf "i4:%s,%s,%s,%s\n" (Z.to_string i1) (Z.to_string i2)
       (Z.to_string i3) (Z.to_string i4) ;
     (i1, i2, i3, i4)
+
+  let logged label ch =
+    Printf.printf "%s%c..." label ch ;
+    ch
 
   let make () =
     object (self)

--- a/spotter.ml
+++ b/spotter.ml
@@ -553,7 +553,7 @@ module Compiler = struct
             ( object (self)
                 (* XXX method dispatch, matcher dispatch *)
                 method call verb args namedArgs : monte option =
-                  Printf.printf "call: %s/%d" verb (List.length args) ;
+                  Printf.printf "(call: %s/%d)" verb (List.length args) ;
                   match
                     AtomDict.find_opt (verb, List.length args) methdict
                   with
@@ -568,7 +568,9 @@ module Compiler = struct
                         List.fold_left2
                           (fun ma p s -> State.and_then ma (p s exit))
                           (State.return ()) params args in
-                      Printf.printf "executing %s" verb ;
+                      Printf.printf "(executing %s(" verb ;
+                      List.iter (fun a -> Printf.printf "%s, " a#stringOf) args ;
+                      Printf.printf ") at %s)" (string_of_span span) ;
                       let o, _ = State.and_then env' body s in
                       Some o
 
@@ -655,6 +657,7 @@ module Compiler = struct
 
   let finalPatt noun guard span specimen exit =
     State.bind (coerceOpt guard specimen exit) (fun s ->
+        Printf.printf "(finalPatt: %s := %s)" noun s#stringOf ;
         (* XXX guards *)
         State.modify (Dict.add noun (bindingObj (finalSlotObj s))))
 
@@ -720,7 +723,7 @@ module MASTContext (Monte : MAST) = struct
     | HMatch of Monte.matcher
 
   let logged label ch =
-    Printf.printf "%s%c..." label ch ;
+    (* XXX Printf.printf "%s%c..." label ch; *)
     ch
 
   let make () =

--- a/spotter.ml
+++ b/spotter.ml
@@ -714,15 +714,6 @@ module MASTContext (Monte : MAST) = struct
     | HMeth of Monte.meth
     | HMatch of Monte.matcher
 
-  let v4 ic =
-    let i1 = input_varint ic in
-    let i2 = input_varint ic in
-    let i3 = input_varint ic in
-    let i4 = input_varint ic in
-    Printf.printf "i4:%s,%s,%s,%s\n" (Z.to_string i1) (Z.to_string i2)
-      (Z.to_string i3) (Z.to_string i4) ;
-    (i1, i2, i3, i4)
-
   let logged label ch =
     Printf.printf "%s%c..." label ch ;
     ch
@@ -736,6 +727,12 @@ module MASTContext (Monte : MAST) = struct
       val patts = backlist ()
 
       method private eat_span ic =
+        let v4 ic =
+          let i1 = input_varint ic in
+          let i2 = input_varint ic in
+          let i3 = input_varint ic in
+          let i4 = input_varint ic in
+          (i1, i2, i3, i4) in
         match input_char ic with
         | 'S' -> Monte.oneToOne (v4 ic)
         | 'B' -> Monte.blob (v4 ic)

--- a/spotter.ml
+++ b/spotter.ml
@@ -961,7 +961,7 @@ end
 
 module M = MASTContext (Compiler)
 
-let read_mast filename =
+let read_mast filename : Compiler.t =
   let ic = open_in_mast filename in
   let context = M.make () in
   let rv = context#eat_last_expr ic in
@@ -969,11 +969,15 @@ let read_mast filename =
 
 let () =
   for i = 1 to Array.length Sys.argv - 1 do
-    Printf.printf "[%i] %s\n" i Sys.argv.(i) ;
     let filename = Sys.argv.(i) in
+    Printf.printf "[%i] %s: read mast\n" i filename ;
     let expr = read_mast filename in
     try
-      let result, _ = expr safeScope in
-      Printf.printf "==> %s\n" result#stringOf
-    with MonteException m -> Printf.printf "%s\n" (string_of_mexn m)
+      Printf.printf "[%i] %s: evaluate module\n" i filename ;
+      let mmod, _ = expr safeScope in
+      Printf.printf "=mod=> %s\n" mmod#stringOf ;
+      Printf.printf "[%i] %s: run module\n" i filename ;
+      let result = call_exn mmod "run" [loaderObj] [] in
+      Printf.printf "=out=> %s\n" result#stringOf
+    with MonteException m -> Printf.printf "\n%s\n" (string_of_mexn m)
   done


### PR DESCRIPTION
current status for prelude.mast:


```
~/projects/spotter$ make spotter.byte && OCAMLRUNPARAM=b ./spotter.byte ./prelude.mast
ocamlbuild -tag debug -use-ocamlfind -pkgs camomile,zarith spotter.byte
Finished, 3 targets (0 cached) in 00:00:00.
[1] ./prelude.mast: read mast
[1] ./prelude.mast: evaluate module
(finalPatt: _comparer := <user>)(finalPatt: makePredicateGuard := <user>)(finalPatt: pred := <user>)(call: run/2)(executing run(<user>, Empty, ) at blob:57:0:57:0)
XXX DeepFrozenStamp.coerce(...) not implemented
(finalPatt: predicate := <user>)
XXX Str.coerce(...) not implemented
(finalPatt: label := Empty)(finalPatt: __return := <ejector at blob:57:0:57:0>)(finalPatt: predicateGuard := <user>)(finalPatt: Empty := <user>)(finalPatt: _mapEmpty := <user>)(finalPatt: _validateFor := <user>)(finalPatt: _ListGuardStamp := <user>)(finalPatt: List := <user>)(finalPatt: _SetGuardStamp := <user>)(finalPatt: Set := <user>)(finalPatt: _MapGuardStamp := <user>)(finalPatt: Map := <user>)(finalPatt: _NullOkStamp := <user>)(finalPatt: NullOk := <user>)(finalPatt: _PairGuardStamp := <user>)(finalPatt: Pair := <user>)(finalPatt: _TupleGuardStamp := <user>)(finalPatt: Tuple := <user>)(finalPatt: _VowStamp := <user>)(finalPatt: Vow := <user>)(finalPatt: _iterForever := <user>)(finalPatt: _splitList := <user>)(finalPatt: _accumulateList := <user>)(finalPatt: nullAuditor := <user>)(finalPatt: _matchSame := <user>)(finalPatt: _mapExtract := <user>)(finalPatt: _quasiMatcher := <user>)(finalPatt: _suchThat := <user>)(finalPatt: _switchFailed := <user>)(finalPatt: _makeVerbFacet := <user>)(finalPatt: _accumulateMap := <user>)(finalPatt: _bind := <user>)(finalPatt: _booleanFlow := <user>)(finalPatt: makeLazySlot := <user>)(finalPatt: promiseAllFulfilled := <user>)
name error at blob:801:15:818:20: _makeMap
```
