### PR TITLE
runtime support for much of prelude.mast

### DIFF
--- a/spotter.ml
+++ b/spotter.ml
@@ -584,45 +584,6 @@ let traceObj suffix : monte =
     method unwrap = None
   end
 
-let safeScope =
-  Dict.of_seq
-    (List.to_seq
-       (List.map
-          (fun (k, v) -> (k, bindingObj (finalSlotObj v)))
-          [ ("Bool", dataGuardObj (MBool true)); ("Bytes", todoGuardObj "Bytes")
-          ; ("Char", dataGuardObj (MChar 32))
-          ; ("DeepFrozen", todoGuardObj "DeepFrozen")
-          ; ("DeepFrozenStamp", todoGuardObj "DeepFrozenStamp")
-          ; ("Double", dataGuardObj (MDouble 1.0))
-          ; ("Infinity", doubleObj infinity); ("NaN", doubleObj nan)
-          ; ("Int", dataGuardObj (MInt Z.zero)); ("Near", todoGuardObj "Near")
-          ; ("Same", todoGuardObj "Same"); ("Ref", todoObj "Ref")
-          ; ("astEval", todoObj "astEval")
-          ; ("Selfless", todoGuardObj "Selfless"); ("Str", todoGuardObj "Str")
-          ; ("SubrangeGuard", todoGuardObj "SubrangeGuard")
-          ; ("Void", voidGuardObj); ("_auditedBy", todoObj "_auditedBy")
-          ; ("_equalizer", todoObj "_equalizer"); ("_loop", todoObj "_loop")
-          ; ("_makeBytes", todoObj "_makeBytes")
-          ; ("_makeDouble", todoObj "_makeDouble")
-          ; ("_makeFinalSlot", todoObj "_makeFinalSlot")
-          ; ("_makeInt", todoObj "_makeInt"); ("_makeList", _makeList)
-          ; ("_makeInt", todoObj "_makeInt"); ("_makeMap", _makeMap)
-          ; ("false", boolObj false); ("null", nullObj)
-          ; ("_makeSourceSpan", todoObj "_makeSourceSpan")
-          ; ("_makeStr", todoObj "_makeStr")
-          ; ("_makeVarSlot", todoObj "_makeVarSlot"); ("M", todoObj "M")
-          ; ("_slotToBinding", todoObj "_slotToBinding")
-          ; ("loadMAST", todoObj "loadMAST")
-          ; ("makeLazySlot", todoObj "makeLazySlot")
-          ; ("promiseAllFulfilled", todoObj "promiseAllFulfilled")
-          ; ("throw", throwObj); ("Any", todoGuardObj "Any")
-          ; ("traceln", traceObj "\n"); ("M", todoObj "M")
-          ; ("true", boolObj true); ("trace", traceObj "")
-          ; ( "typhonAstBuilder"
-            , todoObj "typhonAstBuilder" (* XXX typhon objects? *) )
-          ; ("typhonAstEval", todoObj "typhonAstEval" (* XXX typhon objects? *))
-          ]))
-
 let calling verb args namedArgs target = call_exn target verb args namedArgs
 let get = calling "get" [] []
 let prettyPrint formatter obj = Format.pp_print_string formatter obj#stringOf
@@ -681,6 +642,45 @@ let unwrapList specimen =
   match specimen#unwrap with
   | Some (MList l) -> l
   | _ -> raise (MonteException (WrongType (MList [], specimen)))
+
+let safeScope =
+  Dict.of_seq
+    (List.to_seq
+       (List.map
+          (fun (k, v) -> (k, bindingObj (finalSlotObj v)))
+          [ ("Bool", dataGuardObj (MBool true)); ("Bytes", todoGuardObj "Bytes")
+          ; ("Char", dataGuardObj (MChar 32))
+          ; ("DeepFrozen", todoGuardObj "DeepFrozen")
+          ; ("DeepFrozenStamp", todoGuardObj "DeepFrozenStamp")
+          ; ("Double", dataGuardObj (MDouble 1.0))
+          ; ("Infinity", doubleObj infinity); ("NaN", doubleObj nan)
+          ; ("Int", dataGuardObj (MInt Z.zero)); ("Near", todoGuardObj "Near")
+          ; ("Same", todoGuardObj "Same"); ("Ref", todoObj "Ref")
+          ; ("astEval", todoObj "astEval")
+          ; ("Selfless", todoGuardObj "Selfless"); ("Str", todoGuardObj "Str")
+          ; ("SubrangeGuard", todoGuardObj "SubrangeGuard")
+          ; ("Void", voidGuardObj); ("_auditedBy", todoObj "_auditedBy")
+          ; ("_equalizer", todoObj "_equalizer"); ("_loop", _loop)
+          ; ("_makeBytes", todoObj "_makeBytes")
+          ; ("_makeDouble", todoObj "_makeDouble")
+          ; ("_makeFinalSlot", todoObj "_makeFinalSlot")
+          ; ("_makeInt", todoObj "_makeInt"); ("_makeList", _makeList)
+          ; ("_makeInt", todoObj "_makeInt"); ("_makeMap", _makeMap)
+          ; ("false", boolObj false); ("null", nullObj)
+          ; ("_makeSourceSpan", todoObj "_makeSourceSpan")
+          ; ("_makeStr", todoObj "_makeStr")
+          ; ("_makeVarSlot", todoObj "_makeVarSlot"); ("M", todoObj "M")
+          ; ("_slotToBinding", todoObj "_slotToBinding")
+          ; ("loadMAST", todoObj "loadMAST")
+          ; ("makeLazySlot", todoObj "makeLazySlot")
+          ; ("promiseAllFulfilled", todoObj "promiseAllFulfilled")
+          ; ("throw", throwObj); ("Any", todoGuardObj "Any")
+          ; ("traceln", traceObj "\n"); ("M", todoObj "M")
+          ; ("true", boolObj true); ("trace", traceObj "")
+          ; ( "typhonAstBuilder"
+            , todoObj "typhonAstBuilder" (* XXX typhon objects? *) )
+          ; ("typhonAstEval", todoObj "typhonAstEval" (* XXX typhon objects? *))
+          ]))
 
 let const k _ = k
 

--- a/spotter.ml
+++ b/spotter.ml
@@ -277,10 +277,23 @@ let rec strObj s : monte =
     method unwrap = Some (MStr s)
   end
 
+let flexListObj (init : monte list) : monte =
+  object
+    val mutable items = init
+
+    method call verb args nargs = None
+
+    (* XXX *)
+    method stringOf = "<FlexList>"
+
+    method unwrap = None
+  end
+
 let rec listObj l : monte =
   object
     method call verb args namedArgs =
       match (verb, args) with
+      | "diverge", [] -> Some (flexListObj l)
       | "size", [] -> Some (intObj (Z.of_int (List.length l)))
       | _ -> None
 
@@ -466,6 +479,18 @@ let todoGuardObj name : monte =
     method unwrap = None
   end
 
+let flexMapObj (init : (monte * monte) list) : monte =
+  object
+    val mutable pairs = init
+
+    method call verb args nargs = None
+
+    (* XXX *)
+    method stringOf = "<FlexMap>"
+
+    method unwrap = None
+  end
+
 let mapObj (pairs : (monte * monte) list) : monte =
   (* XXX make sure ej doesn't return. *)
   let throwStr ej msg = call_exn ej "run" [strObj msg] [] in
@@ -492,6 +517,7 @@ let mapObj (pairs : (monte * monte) list) : monte =
   object
     method call (verb : string) (args : monte list) namedArgs : monte option =
       match (verb, args) with
+      | "diverge", [] -> Some (flexMapObj pairs)
       | "_makeIterator", [] -> Some (_makeIterator ())
       | _ ->
           Printf.printf "\nXXX Map verb todo? %s\n" verb ;

--- a/spotter.ml
+++ b/spotter.ml
@@ -266,7 +266,6 @@ let rec strObj s : monte =
       | "size", [] -> Some (intObj (Z.of_int (UTF8.length s)))
       | _ -> None
 
-    (* XXX needs quotes and escapes *)
     method stringOf =
       let parts =
         List.map

--- a/spotter.ml
+++ b/spotter.ml
@@ -261,8 +261,15 @@ let rec intObj i : monte =
 
 let rec strObj s : monte =
   object
-    method call verb args namedArgs =
+    method call verb (args : monte list) namedArgs : monte option =
       match (verb, args) with
+      | "add", [otherObj] -> (
+        match otherObj#unwrap with
+        | Some (MStr other) -> Some (strObj (s ^ other))
+        | Some (MChar other) ->
+            let utf8 code = String.make 0 (Char.chr code) (* XXX *) in
+            Some (strObj (s ^ utf8 other))
+        | _ -> None (* WrongType? fwd ref *) )
       | "size", [] -> Some (intObj (Z.of_int (UTF8.length s)))
       | _ -> None
 

--- a/spotter.ml
+++ b/spotter.ml
@@ -818,16 +818,17 @@ module Compiler = struct
                       None (* refused. XXX matchers *)
                   | Some (params, nParams, body) ->
                       let exit = throwObj in
-                      (* XXX bind namePatt to self *)
                       (* XXX duplicate code with listPatt, refactor! *)
                       let env' =
                         List.fold_left2
                           (fun ma p s -> State.and_then ma (p s exit))
                           (State.return ()) params args in
+                      let env'' =
+                        State.and_then (namePatt self throwObj) env' in
                       Printf.printf "\n(executing %s(" verb ;
                       List.iter (fun a -> Printf.printf "%s, " a#stringOf) args ;
                       Printf.printf ") at %s)" (string_of_span span) ;
-                      let o, _ = State.and_then env' body s in
+                      let o, _ = State.and_then env'' body s in
                       Some o
 
                 (* XXX miranda methods *)


### PR DESCRIPTION
status:

```
~/projects/spotter$ make spotter.byte && OCAMLRUNPARAM=b ./spotter.byte ./prelude.mast

./prelude.mast: read mast
./prelude.mast: evaluate module
(finalPatt: _comparer := <user>)(finalPatt: makePredicateGuard := <user>)(finalPatt: pred := <user>)(call: run/2)
(executing run(<user>, "Empty", ) at blob:57:0:57:0)(finalPatt: makePredicateGuard := <user>)
XXX DeepFrozenStamp.coerce(...) not implemented
(finalPatt: predicate := <user>)
XXX Str.coerce(...) not implemented

...

(executing run("prelude/ast_printer", ) at blob:841:0:841:0)(finalPatt: loadit := <user>)(finalPatt: name := "prelude/ast_printer")(finalPatt: __return := <ejector at blob:841:0:841:0>)prelude/ast_printer.mast: read mast
prelude/ast_printer.mast: evaluate module
=mod=> <user>
(finalPatt: m := <user>)(call: run/1)
(executing run(<user>, ) at blob:1:0:1168:0)(finalPatt: package_1 := <user>)(call: import/1)
(executing import("boot", ) at str:828:40:828:0)(finalPatt: stubLoader := <user>)(finalPatt: name := "boot")(finalPatt: __return := <ejector at str:829:4:829:5>)
Message refused: _equalizer.sameEver/2
```
